### PR TITLE
Token Request specification to allow all parameters in the request body

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,12 +340,17 @@ The Client uses the **"oauth2\_token_url"** to request a token. Example:
 	</tr>
 </table>
 
-The POST request has to be done via HTTP Basic Authorization. Your applications "ClientID" is the username, your "ClientSecret" is the password.
+The POST request can be done via HTTP Basic Authorization with your applications "ClientID" as the username and your "ClientSecret" as the password.
 
 **Post Request Body:** 
 
 	grant_type=authorization_code&code=<YourAccessCode>
 
+Alternatively all parameters may be passed in the token request body
+
+**Post Request Body:** 
+
+	grant_type=authorization_code&code=<YourAccessCode>&client_id=<ClientID>&client_secret=<ClientSecret>
 
 The access token will be returned as JSON in the response body and is an arbitrary string, guaranteed to fit in a varchar(255) field.
 


### PR DESCRIPTION
Here's the small change we discussed in the telco

References:
https://tools.ietf.org/html/rfc6749#section-2.3.1 The OAuth 2.0 Authorization Framework / 2.3.1 Client Password
https://tools.ietf.org/html/rfc6749#section-4.1.3 The OAuth 2.0 Authorization Framework / 4.1.3 Access Token Request
