### PR TITLE
Fix to Make Comments "modified_date" Property Optional

### DIFF
--- a/Schemas_draft-03/Collaboration/Comment/comment_GET.json
+++ b/Schemas_draft-03/Collaboration/Comment/comment_GET.json
@@ -45,7 +45,10 @@
       ]
     },
     "modified_date": {
-      "type": "string"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "modified_author": {
       "type": [


### PR DESCRIPTION
It's currently required by the schema when retrieving comments, which it shouldnt be=)