### PR TITLE
Explicit Specificiation of the Serialization Format for DateTime in Json

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 	- [1.4 Cross origin resource sharing (Cors)](#14-cross-origin-resource-sharing-cors)
 	- [1.5 HTTP status codes](#15-http-status-codes)
 	- [1.6 Error response body format](#16-error-response-body-format)
+	- [1.7 DateTime format](#17-datetime-format)
 - [2. Topologies](#2-topologies)
 	- [2.1 Topology 1 - BCF-Server only](#21-topology-1---bcf-server-only)
 	- [2.2 Topology 2 - Colocated BCF-Server and Model Server](#22-topology-2---colocated-bcf-server-and-model-server)
@@ -154,6 +155,12 @@ The server has a web config file .. "*" means the server allow the resources for
 ## 1.6 Error response body format ##
 
 BCF-API has a specified error response body format [error.json](Schemas_draft-03/error.json).
+
+## 1.7 DateTime format
+
+DateTime values in this API are supposed to be in ISO 8601 compliant `YYYY-MM-DDThh:mm:ss` format with optional time zone indicators. This is the same format as defined in the Xml `xs:dateTime` type as well as the resolt of JavaScripts Date.toJson() output.
+
+For example, `2016-04-28-16:31.27+2:00` would represent _Thursday, April 28th, 2016, 16:31 (270ms) with a time zone offset of +2 hours relative to UTC._
 
 ----------
 


### PR DESCRIPTION
Suggestion to use the regular ISO 8601 format for DateTime representation. The same is used in Xml and is becoming very common in Json APIs as discussed in the Munich Hackathon.