### PR TITLE
Change IfcFiles "file_date" Property to be Optional

### DIFF
--- a/Schemas_draft-03/Collaboration/File/file_GET.json
+++ b/Schemas_draft-03/Collaboration/File/file_GET.json
@@ -23,7 +23,10 @@
       ]
     },
     "date": {
-      "type": "string"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "reference": {
       "type": [

--- a/Schemas_draft-03/Collaboration/File/file_PATCH.json
+++ b/Schemas_draft-03/Collaboration/File/file_PATCH.json
@@ -21,7 +21,10 @@
       ]
     },
     "date": {
-      "type": "string"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "reference": {
       "type": [

--- a/Schemas_draft-03/Collaboration/File/file_PUT.json
+++ b/Schemas_draft-03/Collaboration/File/file_PUT.json
@@ -21,7 +21,10 @@
       ]
     },
     "date": {
-      "type": "string"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "reference": {
       "type": [


### PR DESCRIPTION
Currently the date of referenced Ifc files is required, this is making the actual file date optional since it's not a real identifier and therefore shouldn't be enforced.