### PR TITLE
Added Support for User Defined project_id Values When Creating Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,29 +490,30 @@ Add a new project.
 
 JSON encoded body using the "application/json" content type.
 
-<table border="1">
+|Parameter|Type|Description|Required|
+|---------|----|-----------|--------|
+|name|string|The project name|true|
+|project_id|string|The id of the project|false|
 
-  <tr>
-    <td>name</td>
-    <td>string</td>
-    <td>The project name</td>
-  </tr>
-</table>
+The value of `project_id` must not necessarily be a Guid. This is to support existing project structures and their identification schemes.
 
+**Please note that servers are free to support user defined project_id values.**
+**Servers must auto generate a project_id value when none is supplied.**
 
 **Example Request**
 
     https://example.com/bcf/1.0/projects
-	{
-    "name": "Example project 3"
-	}
+    {
+      "project_id": "B724AAC3-5B2A-234A-D143-AE33CC18414",
+      "name": "Example project 3"
+    }
 
 **Example Response**
 
 
     {
-      "project_id": "B724AAC3-5B2A-234A-D143-AE33CC18414"
-      "name": "Example project 3",
+      "project_id": "B724AAC3-5B2A-234A-D143-AE33CC18414",
+      "name": "Example project 3"
     }
 
 ### 4.1.3 GET Single Project Services ###

--- a/Schemas_draft-03/Project/project_POST.json
+++ b/Schemas_draft-03/Project/project_POST.json
@@ -1,12 +1,18 @@
-  {
-    "$schema": "http://json-schema.org/draft-03/schema#",
-    "title": "project_POST",
-    "description": "Schema for project POST, BCF REST API.",
-    "type": "object",
-    "properties": {
-        "name": {
-            "type": "string",
-            "required": true
-        }
+{
+  "$schema": "http://json-schema.org/draft-03/schema#",
+  "title": "project_POST",
+  "description": "Schema for project POST, BCF REST API.",
+  "type": "object",
+  "properties": {
+    "project_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "name": {
+      "type": "string",
+      "required": true
     }
+  }
 }


### PR DESCRIPTION
This PR adds the optional support to allow specifying the `project_id` when creating a project. This allows better integration between multiple services to have the same project identifiers.
Additionally, dropping the requirement of `project_id`s being Guids to ensure that existing project management structures can be easily extended with a BCF API service. Servers may still enforce a custom format though. 

This was discussed in the Munich Hackathon.

I also changed the properties table for the project object to be a Markdown table instead of Html for better readability and compatibility with Markdown editors.