### PR TITLE
Removed comment Objects "status" and "verbal_status" Properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -1086,24 +1086,21 @@ Retrieve a **collection** of all comments related to a topic.
 **Example Response**
 
     [
-    {
+      {
         "guid": "C4215F4D-AC45-A43A-D615-AA456BEF832B",
-		"status": "open",
-    	"date": "2013-10-21T17:34:22.409Z",
-		"author": "max.muster@example.com",
-		"comment": "Clash found",
-		"topic_guid": "B345F4F2-3A04-B43B-A713-5E456BEF8228"
-		
-    },
-    {
+        "date": "2013-10-21T17:34:22.409Z",
+        "author": "max.muster@example.com",
+        "comment": "Clash found",
+        "topic_guid": "B345F4F2-3A04-B43B-A713-5E456BEF8228"
+      },
+      {
         "guid": "A333FCA8-1A31-CAAC-A321-BB33ABC8414",
-		"status": "closed",
-    	"date": "2013-11-19T14:24:11.316Z",
-		"author": "bob.heater@example.com",		
-		"comment": "will rework the heating model",
-		"topic_guid": "B345F4F2-3A04-B43B-A713-5E456BEF8228"
-    }
-	]
+        "date": "2013-11-19T14:24:11.316Z",
+        "author": "bob.heater@example.com",
+        "comment": "will rework the heating model",
+        "topic_guid": "B345F4F2-3A04-B43B-A713-5E456BEF8228"
+      }
+    ]
 
 ### 4.4.2 POST Comment Services ###
 
@@ -1119,60 +1116,30 @@ Add a new comment to a topic.
 
 JSON encoded body using the "application/json" content type.
 
-
-<table border="1">
-  <tr>
-    <td>verbal_status</td>
-    <td>string</td>
-    <td>The verbal status of a comment (possible values from extension.xsd)</td>
-    <td>optional</td>
-  </tr>
-  <tr>
-    <td>status</td>
-    <td>string</td>
-    <td>The status of a comment (default unknown)</td>
-    <td>mandatory</td>
-  </tr>
-  <tr>
-    <td>comment</td>
-    <td>string</td>
-    <td>The comment</td>
-    <td>mandatory</td>
-  </tr>
-  <tr>
-    <td>viewpoint_guid</td>
-    <td>string</td>
-    <td>The GUID of the related viewpoint</td>
-    <td>optional</td>
-  </tr>
-  <tr>
-    <td>reply_to_comment_guid</td>
-    <td>string</td>
-    <td>GUID of the comment to which this comment replies to</td>
-    <td>optional</td>
-  </tr>
-</table>
+|Parameter|Type|Description|Required|
+|---------|----|-----------|--------|
+|comment|string|The comment text|true|
+|viewpoint_guid|string|The GUID of the related viewpoint|false|
+|reply_to_comment_guid|string|GUID of the comment to which this comment replies to|false|
 
 **Example Request**
 
 	https://example.com/bcf/1.0/projects/F445F4F2-4D02-4B2A-B612-5E456BEF9137/topics/B345F4F2-3A04-B43B-A713-5E456BEF8228/comments
 
     {
-		"verbal_status": "closed",
-		"status": "closed",	
-		"comment": "will rework the heating model",
+      "comment": "will rework the heating model",
     }
 
 **Example Response**
 
     {
-        "guid": "A333FCA8-1A31-CAAC-A321-BB33ABC8414",
-		"verbal_status": "closed",
-		"status": "closed",
-    	"date": "2013-11-19T14:24:11.316Z",
-		"author": "bob.heater@example.com",		
-		"comment": "will rework the heating model",
-		"topic_guid": "B345F4F2-3A04-B43B-A713-5E456BEF8228"
+      "guid": "A333FCA8-1A31-CAAC-A321-BB33ABC8414",
+      "verbal_status": "closed",
+      "status": "closed",
+      "date": "2013-11-19T14:24:11.316Z",
+      "author": "bob.heater@example.com",
+      "comment": "will rework the heating model",
+      "topic_guid": "B345F4F2-3A04-B43B-A713-5E456BEF8228"
     }
 
 ### 4.4.3 GET Single Comment Services ###
@@ -1192,13 +1159,11 @@ Get a single comment.
 **Example Response**
 
     {
-        "guid": "A333FCA8-1A31-CAAC-A321-BB33ABC8414",
-		"verbal_status": "closed",
-		"status": "closed",
-    	"date": "2013-11-19T14:24:11.316Z",
-		"author": "bob.heater@example.com",		
-		"comment": "will rework the heating model",
-		"topic_guid": "B345F4F2-3A04-B43B-A713-5E456BEF8228"
+      "guid": "A333FCA8-1A31-CAAC-A321-BB33ABC8414",
+      "date": "2013-11-19T14:24:11.316Z",
+      "author": "bob.heater@example.com",
+      "comment": "will rework the heating model",
+      "topic_guid": "B345F4F2-3A04-B43B-A713-5E456BEF8228"
     }
 
 ### 4.4.4 PUT Single Comment Services ###

--- a/Schemas_draft-03/Collaboration/Comment/comment_GET.json
+++ b/Schemas_draft-03/Collaboration/Comment/comment_GET.json
@@ -6,16 +6,6 @@
       "required": true,
       "type": "string"
     },
-    "verbal_status": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "status": {
-      "required": true,
-      "type": "string"
-    },
     "date": {
       "required": true,
       "type": "string"

--- a/Schemas_draft-03/Collaboration/Comment/comment_PATCH.json
+++ b/Schemas_draft-03/Collaboration/Comment/comment_PATCH.json
@@ -2,18 +2,6 @@
   "title": "comment_PATCH",
   "type": "object",
   "properties": {
-    "verbal_status": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "status": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
     "comment": {
       "type": [
         "string",

--- a/Schemas_draft-03/Collaboration/Comment/comment_POST.json
+++ b/Schemas_draft-03/Collaboration/Comment/comment_POST.json
@@ -2,16 +2,6 @@
   "title": "comment_POST",
   "type": "object",
   "properties": {
-    "verbal_status": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "status": {
-      "required": true,
-      "type": "string"
-    },
     "comment": {
       "required": true,
       "type": "string"

--- a/Schemas_draft-03/Collaboration/Comment/comment_PUT.json
+++ b/Schemas_draft-03/Collaboration/Comment/comment_PUT.json
@@ -2,16 +2,6 @@
   "title": "comment_PUT",
   "type": "object",
   "properties": {
-    "verbal_status": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "status": {
-      "required": true,
-      "type": "string"
-    },
     "comment": {
       "required": true,
       "type": "string"


### PR DESCRIPTION
[Fix for Issue 19](https://github.com/BuildingSMART/BCF-API/issues/19) due to the status and verbal_status being deprecated in BCF XML.
Only the topic object itself should be responsibly for handling it's status and the creation or modification of a comment does not result in an implicit change of topic status.

I also changed the properties table for the comment object to be a Markdown table instead of Html for better readability and compatibility with Markdown editors.