### PR TITLE
Changed topic Objects "reference_links" Property to be an Array

### DIFF
--- a/README.md
+++ b/README.md
@@ -814,7 +814,7 @@ JSON encoded body using the "application/json" content type.
 |---------|----|-----------|--------|
 |topic_type|string|The type of a topic (value from extension.xsd)|false|
 |topic_status|string|The status of a topic (value from extension.xsd)|false|
-|reference_links|string|Reference links, i.e. links to referenced resources|false|
+|reference_links|array (string)|Reference links, i.e. links to referenced resources|false|
 |title|string|The title of a topic|true|
 |priority|string|The priority of a topic (value from extension.xsd)|false|
 |index|integer|The index of a topic|false|

--- a/README.md
+++ b/README.md
@@ -810,108 +810,46 @@ Add a new topic.
 
 JSON encoded body using the "application/json" content type.
 
+|Parameter|Type|Description|Required|
+|---------|----|-----------|--------|
+|topic_type|string|The type of a topic (value from extension.xsd)|false|
+|topic_status|string|The status of a topic (value from extension.xsd)|false|
+|reference_links|string|Reference links, i.e. links to referenced resources|false|
+|title|string|The title of a topic|true|
+|priority|string|The priority of a topic (value from extension.xsd)|false|
+|index|integer|The index of a topic|false|
+|labels|array (string)|The collection of labels of a topic (values from extension.xsd)|false|
+|assigned_to|string|UserID assigned to a topic (value from extension.xsd)|false|
+|description|string|Description of a topic|false|
+|bim_snippet.snippet_type|string|Type of a BIM-Snippet of a topic (value from extension.xsd)|false|
+|bim_snippet.is_external|boolean|Is the BIM-Snippet external (default = false)|false|
+|bim_snippet.reference|string|Reference of a BIM-Snippet of a topic|false|
+|bim_snippet.reference_schema|string|Schema of a BIM-Snippet of a topic|false|
 
-<table border="1">
-  <tr>
-    <td>topic_type</td>
-    <td>string</td>
-    <td>The type of a topic (value from extension.xsd)</td>
-    <td>optional</td>
-  </tr>
-  <tr>
-    <td>topic_status</td>
-    <td>string</td>
-    <td>The status of a topic (value from extension.xsd)</td>
-    <td>optional</td>
-  </tr>
-  <tr>
-    <td>reference_link</td>
-    <td>string</td>
-    <td>Reference link</td>
-    <td>optional</td>
-  </tr>
-  <tr>
-    <td>title</td>
-    <td>string</td>
-    <td>The title of a topic</td>
-    <td>mandatory</td>
-  </tr>
-  <tr>
-    <td>priority</td>
-    <td>string</td>
-    <td>The priority of a topic (value from extension.xsd)</td>
-    <td>optional</td>
-  </tr>
-  <tr>
-    <td>index</td>
-    <td>integer</td>
-    <td>The index of a topic</td>
-    <td>optional</td>
-  </tr>
-  <tr>
-    <td>labels</td>
-    <td>string</td>
-    <td>The collection of labels of a topic (values from extension.xsd)</td>
-    <td>optional</td>
-  </tr>
-  <tr>
-    <td>assigned_to</td>
-    <td>string</td>
-    <td>UserID assigned to a topic (value from extension.xsd)</td>
-    <td>optional</td>
-  </tr>
-  <tr>
-    <td>description</td>
-    <td>string</td>
-    <td>Description of a topic</td>
-    <td>optional</td>
-  </tr>
-  <tr>
-    <td>snippet_type</td>
-    <td>string</td>
-    <td>Type of a BIM-Snippet of a topic (value from extension.xsd)</td>
-    <td>mandatory if BIM-Snippet exists</td>
-  </tr>
-  <tr>
-    <td>is_external</td>
-    <td>boolean</td>
-    <td>Is the BIM-Snippet external (default = false)</td>
-    <td>optional</td>
-  </tr>
-  <tr>
-    <td>reference</td>
-    <td>string</td>
-    <td>Reference of a BIM-Snippet of a topic</td>
-    <td>mandatory if BIM-Snippet exists</td>
-  </tr>
-  <tr>
-    <td>reference_schema</td>
-    <td>string</td>
-    <td>Schema of a BIM-Snippet of a topic</td>
-    <td>mandatory if BIM-Snippet exists</td>
-  </tr>
-</table>
+_Note: If "bim_snippet" is present, then all four properties (`snippet_type`, `is_external`, `reference` and `reference_schema`) are mandatory._
 
 **Example Request**
 
     https://example.com/bcf/1.0/projects/F445F4F2-4D02-4B2A-B612-5E456BEF9137/topics
-	    {
-		"topic_type": "Clash",
-		"topic_status": "open",
-        "title": "Example topic 3",
-		"priority": "high",
-        "labels": [
-            "Architecture",
-            "Heating"],
-		"assigned_to": "harry.muster@example.com",
-        "bim_snippet":
-				{
-				"snippet_type": "clash",
-				"is_external": true,
-				"reference": "https://example.com/bcf/1.0/ADFE23AA11BCFF444122BB",
-				"reference_schema": "https://example.com/bcf/1.0/clash.xsd"	
-				}
-    	}
+
+    POST Body:
+    {
+      "topic_type": "Clash",
+      "topic_status": "open",
+      "title": "Example topic 3",
+      "priority": "high",
+      "labels": [
+        "Architecture",
+        "Heating"
+      ],
+      "assigned_to": "harry.muster@example.com",
+      "bim_snippet": {
+        "snippet_type": "clash",
+        "is_external": true,
+        "reference": "https://example.com/bcf/1.0/ADFE23AA11BCFF444122BB",
+        "reference_schema": "https://example.com/bcf/1.0/clash.xsd"	
+      }
+    }
 
 ### 4.2.3 GET Single Topic Services ###
 

--- a/Schemas_draft-03/Collaboration/Topic/topic_GET.json
+++ b/Schemas_draft-03/Collaboration/Topic/topic_GET.json
@@ -18,11 +18,14 @@
         "null"
       ]
     },
-    "reference_link": {
+    "reference_links": {
       "type": [
-        "string",
+        "array",
         "null"
-      ]
+      ],
+      "items": {
+        "type": "string"
+      }
     },
     "title": {
       "required": true,

--- a/Schemas_draft-03/Collaboration/Topic/topic_PATCH.json
+++ b/Schemas_draft-03/Collaboration/Topic/topic_PATCH.json
@@ -14,11 +14,14 @@
         "null"
       ]
     },
-    "reference_link": {
+    "reference_links": {
       "type": [
-        "string",
+        "array",
         "null"
-      ]
+      ],
+      "items": {
+        "type": "string"
+      }
     },
     "title": {
       "type": [

--- a/Schemas_draft-03/Collaboration/Topic/topic_POST.json
+++ b/Schemas_draft-03/Collaboration/Topic/topic_POST.json
@@ -16,11 +16,14 @@
         "null"
       ]
     },
-    "reference_link": {
+    "reference_links": {
       "type": [
-        "string",
+        "array",
         "null"
-      ]
+      ],
+      "items": {
+        "type": "string"
+      }
     },
     "title": {
       "required": true,

--- a/Schemas_draft-03/Collaboration/Topic/topic_PUT.json
+++ b/Schemas_draft-03/Collaboration/Topic/topic_PUT.json
@@ -16,11 +16,14 @@
         "null"
       ]
     },
-    "reference_link": {
+    "reference_links": {
       "type": [
-        "string",
+        "array",
         "null"
-      ]
+      ],
+      "items": {
+        "type": "string"
+      }
     },
     "title": {
       "required": true,


### PR DESCRIPTION
This just adds the capability of having multiple `reference_link`s within a topic.

I also changed the properties table for the topic object to be a Markdown table instead of Html for better readability and compatibility with Markdown editors. (This will create merge errors with the other pull requests=)