### PR TITLE
Feature/fix viewpoint component links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1692,7 +1692,7 @@ Retrieve a specific viewpoints bitmap image file (png or jpg).
 
     GET /bcf/{version}/projects/{project_id}/topics/{guid}/viewpoints/{guid}/selection
 
-[component_GET.json](Schemas_draft-03/Collaboration/Component/selection_GET.json)
+[selection_GET.json](Schemas_draft-03/Collaboration/Viewpoint/selection_GET.json)
 
 Retrieve a **collection** of all selected components in a viewpoint.
 
@@ -1704,15 +1704,17 @@ Retrieve a **collection** of all selected components in a viewpoint.
 
     Response Code: 200 - OK
     Body:
-    [
-        {
-            "ifc_guid": "2MF28NhmDBiRVyFakgdbCT",
-            "originating_system": "Example CAD Application",
-            "authoring_tool_id": "EXCAD/v1.0"
-        }, {
-            "ifc_guid": "3$cshxZO9AJBebsni$z9Yk",
-        }
-    ]
+    {
+        "selection": [
+            {
+                "ifc_guid": "2MF28NhmDBiRVyFakgdbCT",
+                "originating_system": "Example CAD Application",
+                "authoring_tool_id": "EXCAD/v1.0"
+            }, {
+                "ifc_guid": "3$cshxZO9AJBebsni$z9Yk",
+            }
+        ]
+    }
 
 ### 4.5.7 GET colored Components Service
 

--- a/README.md
+++ b/README.md
@@ -1711,7 +1711,7 @@ Retrieve a **collection** of all selected components in a viewpoint.
                 "originating_system": "Example CAD Application",
                 "authoring_tool_id": "EXCAD/v1.0"
             }, {
-                "ifc_guid": "3$cshxZO9AJBebsni$z9Yk",
+                "ifc_guid": "3$cshxZO9AJBebsni$z9Yk"
             }
         ]
     }
@@ -1722,7 +1722,7 @@ Retrieve a **collection** of all selected components in a viewpoint.
 
     GET /bcf/{version}/projects/{project_id}/topics/{guid}/viewpoints/{guid}/coloring
 
-[component_GET.json](Schemas_draft-03/Collaboration/Component/coloring_GET.json)
+[coloring_GET.json](Schemas_draft-03/Collaboration/Viewpoint/coloring_GET.json)
 
 Retrieve a **collection** of all colored components in a viewpoint.
 
@@ -1734,20 +1734,22 @@ Retrieve a **collection** of all colored components in a viewpoint.
 
     Response Code: 200 - OK
     Body:
-    [
-        {
-            "color": "#ff0000",
-            "components": [
-                {
-                    "ifc_guid": "2MF28NhmDBiRVyFakgdbCT",
-                    "originating_system": "Example CAD Application",
-                    "authoring_tool_id": "EXCAD/v1.0"
-                }, {
-                    "ifc_guid": "3$cshxZO9AJBebsni$z9Yk",
-                }
-            ]
-        }
-    ]
+    {
+        "coloring": [
+            {
+                "color": "#ff0000",
+                "components": [
+                    {
+                        "ifc_guid": "2MF28NhmDBiRVyFakgdbCT",
+                        "originating_system": "Example CAD Application",
+                        "authoring_tool_id": "EXCAD/v1.0"
+                    }, {
+                        "ifc_guid": "3$cshxZO9AJBebsni$z9Yk"
+                    }
+                ]
+            }
+        ]
+    }
 
 ### 4.5.8 GET visibility of Components Service
 

--- a/README.md
+++ b/README.md
@@ -1757,7 +1757,7 @@ Retrieve a **collection** of all colored components in a viewpoint.
 
     GET /bcf/{version}/projects/{project_id}/topics/{guid}/viewpoints/{guid}/visibility
 
-[visibility_GET.json](Schemas_draft-03/Collaboration/Component/visibility_GET.json)
+[visibility_GET.json](Schemas_draft-03/Collaboration/Viewpoint/visibility_GET.json)
 
 Retrieve visibility of components in a viewpoint.
 
@@ -1769,21 +1769,23 @@ Retrieve visibility of components in a viewpoint.
 
     Response Code: 200 - OK
     Body:
-     {
-        "default_visibility": true,
-        "exceptions": [
-            {
-                "ifc_guid": "2MF28NhmDBiRVyFakgdbCT",
-                "originating_system": "Example CAD Application",
-                "authoring_tool_id": "EXCAD/v1.0"
-            }, {
-                "ifc_guid": "3$cshxZO9AJBebsni$z9Yk",
+    {
+        "visibility": {
+                "default_visibility": true,
+            "exceptions": [
+                {
+                    "ifc_guid": "2MF28NhmDBiRVyFakgdbCT",
+                    "originating_system": "Example CAD Application",
+                    "authoring_tool_id": "EXCAD/v1.0"
+                }, {
+                    "ifc_guid": "3$cshxZO9AJBebsni$z9Yk",
+                }
+            ],
+            "view_setup_hints": {
+                "spaces_visible": true,
+                "space_boundaries_visible": false,
+                "openings_visible": true
             }
-        ],
-        "view_setup_hints": {
-            "spaces_visible": true,
-            "space_boundaries_visible": false,
-            "openings_visible": true
         }
     }
 

--- a/Schemas_draft-03/Collaboration/Viewpoint/view_setup_hints.json
+++ b/Schemas_draft-03/Collaboration/Viewpoint/view_setup_hints.json
@@ -1,5 +1,5 @@
 {
-    "type": ["object", null],
+    "type": ["object", "null"],
     "properties": {
         "spaces_visible": {
             "type": "boolean",


### PR DESCRIPTION
Fixes wrong urls (generating 404s when navigating to the JSON schemas) and corrects examples in the spec (removes trailing commas and adjusts the examples to be in sync with the schemas)

Thanks to @KevLoh for finding the issues!