### PR TITLE
Issue #208: Add priority filtering option for BCF API 2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,6 +688,7 @@ Retrieve a **collection** of topics related to a project (default sort order is 
 |creation_date|datetime|creation date of a topic|
 |modified_date|datetime|modification date of a topic|
 |labels|array (string)|labels of a topic (value from extensions)|
+|priority|string|priority of a topic (value from extensions)|
 
 **Odata sort parameters**
 


### PR DESCRIPTION
Topic priority has been added as Odata filter parameter for BCF API 2.2

Fixes #208 
 
Testing
-------

1. Tested by verifying that priority OData filter parameter is shown properly in the correct section

![Screenshot 2020-07-07 at 10 12 30 AM](https://user-images.githubusercontent.com/46447016/86734593-c5f49c80-c03a-11ea-9b55-950d96f401f2.png)
