### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,7 +700,7 @@ Get topics that are open, assigned to Architect@example.com and created after De
 Odata does not support list operators. To achieve list query, use the 'or' operator.
 Get topics that have at least one of the labels 'Architecture', 'Structural' or 'Heating'
 
-    GET /bcf/1.0/projects/F445F4F2-4D02-4B2A-B612-5E456BEF9137/topics?$filter=contains(labels, 'Architecture') or contains(labels, 'Structural') or contains(labels, 'Heating')
+    GET /bcf/2.1/projects/F445F4F2-4D02-4B2A-B612-5E456BEF9137/topics?$filter=labels/any(label: label eq 'Architecture') or labels/any(label: label eq 'Structural') or labels/any(label: label eq 'Heating')
 
 **Example Request**
 


### PR DESCRIPTION
Corrected unsupported OData example.
OData v4 "contains" supports strings (i.e. contains(string_property, '@')) or array properties when the second parameter is another array (contains(array_property, other_array)). The example used contains(array_property, string) which is not supported and does not work when using the Microsoft OData Nuget package.

In this case it is actually better to use property_name/any({expression}) for filtering.