### PR TITLE
Ability to sort by server_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -696,6 +696,7 @@ Retrieve a **collection** of topics related to a project (default sort order is 
 |---------|-----------|
 |creation_date|creation date of a topic|
 |modified_date|modification date of a topic|
+|server_id|the [server_id](#429-topic-identifiers) of the topic|
 |index|index of a topic|
 
 **Example Request with odata**


### PR DESCRIPTION
Added ability to sort by `server_id`, matching its sort/search capability to what is currently supported for `index`.