### PR TITLE
Issue #211 : Clarify the workflow for Topic Modification date upon Comment modification and floating viewpoint addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -705,7 +705,7 @@ Retrieve a **collection** of topics related to a project (default sort order is 
 |topic_status|string|status of a topic (value from extensions)|
 |topic_type|string|type of a topic (value from extensions)|
 |creation_date|datetime|creation date of a topic|
-|modified_date|datetime|modification date of a topic|
+|modified_date|datetime|modification date of a topic. The modification date of a server's topic should be the latest value of when the topic has been modified or when the latest [comment](#44-comment-services) has been updated or when a "floating viewpoint" (a [viewpoint](#45-viewpoint-services) which is not associated with a comment) is added|
 |labels|array (string)|labels of a topic (value from extensions)|
 |priority|string|priority of a topic (value from extensions)|
 


### PR DESCRIPTION
Information added regarding the Topic modification date update upon latest topic and comment modification and floating viewpoint addition.

Testing Details:

<img width="1043" alt="Screenshot 2020-11-20 at 23 03 48" src="https://user-images.githubusercontent.com/46447016/99849884-03d70500-2b85-11eb-9671-9194a5ada330.png">
