### PR TITLE
Add parent/child relation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1822,6 +1822,8 @@ Retrieve a **collection** of all related topics to a topic.
 
 Add or update a **collection** of all related topics to a topic. This operation is only possible when the server returns the `updateRelatedTopics` flag in the Topic authorization, see section [3.2.8](#328-determining-allowed-topic-modifications)
 
+Throws "409 Conflict" if requestion to add a parent-child relation causing an infinite loop. Example: TopicA is already the parent of TopicB. Making TopicB the parent of TopicA is not allowed, as it will cause an infinite tree-structure.
+
 **Example Request**
 
     PUT /bcf/3.0/projects/F445F4F2-4D02-4B2A-B612-5E456BEF9137/topics/B345F4F2-3A04-B43B-A713-5E456BEF8228/related_topics

--- a/README.md
+++ b/README.md
@@ -748,11 +748,6 @@ The global default Topic authorizations are expressed in the project schema and 
 query parameter "includeAuthorization" equal to "true" Topics will include an "authorization" field containing any local
 overrides for each Topic.
 
-### 3.2.8 Including topic relations when returning topics
-
-The topic relations are defined in the schema and when Topic(s) are requested with the
-query parameter "includeTopicRelations" equal to "true" Topics will include a "topic_relations" field containing any relations for each Topic.
-
 ### 3.2.9 Topic Identifiers
 
 Each topic has two identifiers: 

--- a/README.md
+++ b/README.md
@@ -748,6 +748,11 @@ The global default Topic authorizations are expressed in the project schema and 
 query parameter "includeAuthorization" equal to "true" Topics will include an "authorization" field containing any local
 overrides for each Topic.
 
+### 3.2.8 Including topic relations when returning topics
+
+The topic relations are defined in the schema and when Topic(s) are requested with the
+query parameter "includeTopicRelations" equal to "true" Topics will include a "topic_relations" field containing any relations for each Topic.
+
 ### 3.2.9 Topic Identifiers
 
 Each topic has two identifiers: 

--- a/README.md
+++ b/README.md
@@ -1822,7 +1822,7 @@ Retrieve a **collection** of all related topics to a topic.
 
 Add or update a **collection** of all related topics to a topic. This operation is only possible when the server returns the `updateRelatedTopics` flag in the Topic authorization, see section [3.2.8](#328-determining-allowed-topic-modifications)
 
-Throws "409 Conflict" if requestion to add a parent-child relation causing an infinite loop. Example: TopicA is already the parent of TopicB. Making TopicB the parent of TopicA is not allowed, as it will cause an infinite tree-structure.
+Throws "409 Conflict" if requesting to add a parent-child relation causing an infinite loop. Example: TopicA is already the parent of TopicB. Making TopicB the parent of TopicA is not allowed, as it will cause an infinite tree-structure.
 
 **Example Request**
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@
 [BCF-API on SwaggerHub](https://app.swaggerhub.com/apis/buildingSMART/BCF/3.0)  
 > The Swagger / OpenAPI specification is offered as a reference for implementers. The BCF group may update it and fix issues as necessary at any time.
 
+# Contributing
+
+The Open CDE workgroup develops the BCF standard. The group meets every second Monday at 11am CET. To join the fortnightly meeting please email [opencde@buildingsmart.org](mailto:opencde@buildingsmart.org). 
+
 **Table of Contents**
 
 <!-- toc -->

--- a/README.md
+++ b/README.md
@@ -1822,7 +1822,7 @@ Retrieve a **collection** of all related topics to a topic.
 
 Add or update a **collection** of all related topics to a topic. This operation is only possible when the server returns the `updateRelatedTopics` flag in the Topic authorization, see section [3.2.8](#328-determining-allowed-topic-modifications)
 
-Throws "409 Conflict" if requesting to add a parent-child relation causing an infinite loop. Example: TopicA is already the parent of TopicB. Making TopicB the parent of TopicA is not allowed, as it will cause an infinite tree-structure.
+Throws "409 Conflict" if requesting to add a parent-child relation causing an infinite loop. Example: TopicA is already the parent of TopicB. Making TopicB the parent of TopicA is not allowed.
 
 **Example Request**
 

--- a/Schemas_draft-03/Collaboration/RelatedTopic/related_topic_GET.json
+++ b/Schemas_draft-03/Collaboration/RelatedTopic/related_topic_GET.json
@@ -7,6 +7,11 @@
         "related_topic_guid": {
             "required": true,
             "type": "string"
+        },
+        "relation_type": {
+            "required": true,
+            "type": "string",
+            "enum": ["relates", "parent", "child"]
         }
     }
 }

--- a/Schemas_draft-03/Collaboration/RelatedTopic/related_topic_PUT.json
+++ b/Schemas_draft-03/Collaboration/RelatedTopic/related_topic_PUT.json
@@ -7,6 +7,11 @@
         "related_topic_guid": {
             "required": true,
             "type": "string"
+        },
+        "relation_type": {
+            "required": true,
+            "type": "string",
+            "enum": ["relates", "parent", "child"]
         }
     }
 }

--- a/Schemas_draft-03/Collaboration/Topic/topic_GET.json
+++ b/Schemas_draft-03/Collaboration/Topic/topic_GET.json
@@ -84,12 +84,6 @@
         "custom_fields": {
             "$ref": "custom_fields.json"
         },
-        "related_topics": {
-            "type": ["array", "null"],
-            "items": {
-                "$ref": "../RelatedTopic/related_topic_GET.json"
-            }
-        },
         "authorization": {
             "type": "object",
             "required": false,

--- a/Schemas_draft-03/Collaboration/Topic/topic_GET.json
+++ b/Schemas_draft-03/Collaboration/Topic/topic_GET.json
@@ -85,7 +85,10 @@
             "$ref": "custom_fields.json"
         },
         "related_topics": {
-            "$ref": "related_topics.json"
+            "type": ["array", "null"],
+            "items": {
+                "$ref": "../RelatedTopic/related_topic_GET.json"
+            }
         },
         "authorization": {
             "type": "object",

--- a/Schemas_draft-03/Collaboration/Topic/topic_GET.json
+++ b/Schemas_draft-03/Collaboration/Topic/topic_GET.json
@@ -84,6 +84,9 @@
         "custom_fields": {
             "$ref": "custom_fields.json"
         },
+        "related_topics": {
+            "$ref": "related_topics.json"
+        },
         "authorization": {
             "type": "object",
             "required": false,

--- a/Schemas_draft-03/Project/extensions_GET.json
+++ b/Schemas_draft-03/Project/extensions_GET.json
@@ -74,6 +74,14 @@
         "comment_actions": {
             "$ref": "../Collaboration/Action/comment_actions.json"
         },
+        "relation_types": {
+            "required": false,
+            "type": "array",
+            "items": {
+                "type": "string",
+                "enum": ["relates", "parent-child"]
+            }
+        },
         "custom_fields": {
             "type": ["array"],
             "items": {


### PR DESCRIPTION
All existing relations defaults to relationType: "relates" 

When adding a child relation to a topic, and getting relations for the child, the "parent" relation should be returned
When adding a parent relation to a topic, and getting relations for the parent, the "child" relation should be returned

Parent/child relations that ends up in an infinite loop should be blocked

Include of topic relations PR is here: #315 