### PR TITLE
Identifying guids

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,7 +584,7 @@ _Note: If "bim_snippet" is present, then all four properties (`snippet_type`, `i
 
 **Resource URL**
 
-    GET /bcf/{version}/projects/{guid}/topics/{guid}
+    GET /bcf/{version}/projects/{project_id}/topics/{topic_guid}
 
 [topic_GET.json](Schemas_draft-03/Collaboration/Topic/topic_GET.json)
 
@@ -630,7 +630,7 @@ Retrieve a specific topic.
 
 **Resource URL**
 
-    PUT /bcf/{version}/projects/{project_id}/topics/{guid}
+    PUT /bcf/{version}/projects/{project_id}/topics/{topic_guid}
 
 [topic_PUT.json](Schemas_draft-03/Collaboration/Topic/topic_PUT.json)
 
@@ -690,7 +690,7 @@ Modify a specific topic, description similar to POST. This operation is only pos
 
 **Resource URL**
 
-    DELETE /bcf/{version}/projects/{project_id}/topics/{guid}
+    DELETE /bcf/{version}/projects/{project_id}/topics/{topic_guid}
 
 Deletes a single topic. This operation is only possible when the server returns the `delete` flag in the Topic authorization, see section [3.2.8](#328-determining-allowed-topic-modifications)
 
@@ -706,7 +706,7 @@ Deletes a single topic. This operation is only possible when the server returns 
 
 **Resource URL**
 
-    GET /bcf/{version}/projects/{project_id}/topics/{guid}/snippet
+    GET /bcf/{version}/projects/{project_id}/topics/{topic_guid}/snippet
 
 Retrieves a topics BIM-Snippet as binary file.
 
@@ -714,7 +714,7 @@ Retrieves a topics BIM-Snippet as binary file.
 
 **Resource URL**
 
-    PUT /bcf/{version}/projects/{project_id}/topics/{guid}/snippet
+    PUT /bcf/{version}/projects/{project_id}/topics/{topic_guid}/snippet
 
 Puts a new BIM Snippet binary file to a topic. If this is used, the parent topics BIM Snippet property `is_external` must be set to `false` and the `reference` must be the file name with extension. This operation is only possible when the server returns the `updateBimSnippet` flag in the Topic authorization, see section [3.2.8](#328-determining-allowed-topic-modifications)
 
@@ -811,7 +811,7 @@ user choose to associate a topic with that `File`.
 
 **Resource URL**
 
-    GET /bcf/{version}/projects/{project_id}/topics/{guid}/files
+    GET /bcf/{version}/projects/{project_id}/topics/{topic_guid}/files
 
 [file_GET.json](Schemas_draft-03/Collaboration/File/file_GET.json)
 
@@ -843,7 +843,7 @@ Retrieve a **collection** of file references as topic header.
 
 **Resource URL**
 
-    PUT /bcf/{version}/projects/{project_id}/topics/{guid}/files
+    PUT /bcf/{version}/projects/{project_id}/topics/{topic_guid}/files
 
 [file_PUT.json](Schemas_draft-03/Collaboration/File/file_PUT.json)
 
@@ -883,7 +883,7 @@ Update a **collection** of file references on the topic header. This operation i
 
 **Resource URL**
 
-    GET /bcf/{version}/projects/{project_id}/topics/{guid}/comments
+    GET /bcf/{version}/projects/{project_id}/topics/{guid_topic}/comments
 
 [comment_GET.json](Schemas_draft-03/Collaboration/Comment/comment_GET.json)
 
@@ -939,7 +939,7 @@ Get comments that are created after December 5 2015. Sort the result on first cr
 
 **Resource URL**
 
-    POST /bcf/{version}/projects/{project_id}/topics/{guid}/comments
+    POST /bcf/{version}/projects/{project_id}/topics/{topic_guid}/comments
 
 [comment_POST.json](Schemas_draft-03/Collaboration/Comment/comment_POST.json)
 
@@ -979,7 +979,7 @@ JSON encoded body using the "application/json" content type.
 
 **Resource URL**
 
-    GET /bcf/{version}/projects/{project_id}/topics/{guid}/comments/{guid}
+    GET /bcf/{version}/projects/{project_id}/topics/{topic_guid}/comments/{comment_guid}
 
 [comment_GET.json](Schemas_draft-03/Collaboration/Comment/comment_GET.json)
 
@@ -1005,7 +1005,7 @@ Get a single comment.
 
 **Resource URL**
 
-    PUT /bcf/{version}/projects/{project_id}/topics/{guid}/comments/{guid}
+    PUT /bcf/{version}/projects/{project_id}/topics/{topic_guid}/comments/{comment_guid}
 
 [comment_PUT.json](Schemas_draft-03/Collaboration/Comment/comment_PUT.json)
 
@@ -1037,7 +1037,7 @@ Update a single comment, description similar to POST. This operation is only pos
 
 **Resource URL**
 
-    DELETE /bcf/{version}/projects/{project_id}/topics/{guid}/comments/{guid}
+    DELETE /bcf/{version}/projects/{project_id}/topics/{topic_guid}/comments/{comment_guid}
 
 Deletes a single comment. This operation is only possible when the server returns the `delete` flag in the Comment authorization, see section [3.4.6](#346-determining-allowed-comment-modifications)
 
@@ -1063,7 +1063,7 @@ Viewpoints are described in detail in [BCF-XML](https://github.com/buildingSMART
 
 **Resource URL**
 
-    GET /bcf/{version}/projects/{project_id}/topics/{guid}/viewpoints
+    GET /bcf/{version}/projects/{project_id}/topics/{topic_guid}/viewpoints
 
 [viewpoint_GET.json](Schemas_draft-03/Collaboration/Viewpoint/viewpoint_GET.json)
 
@@ -1173,7 +1173,7 @@ Retrieve a **collection** of all viewpoints related to a topic.
 
 **Resource URL**
 
-    POST /bcf/{version}/projects/{project_id}/topics/{guid}/viewpoints
+    POST /bcf/{version}/projects/{project_id}/topics/{topic_guid}/viewpoints
 
 [viewpoint_POST.json](Schemas_draft-03/Collaboration/Viewpoint/viewpoint_POST.json)
 
@@ -1525,7 +1525,7 @@ BCF is suitable for hiding/showing a few components. A huge list of hidden/shown
 
 **Resource URL**
 
-    GET /bcf/{version}/projects/{guid}/topics/{guid}/viewpoints/{guid}
+    GET /bcf/{version}/projects/{project_id}/topics/{topic_guid}/viewpoints/{viewpoint_guid}
 
 [viewpoint_GET.json](Schemas_draft-03/Collaboration/Viewpoint/viewpoint_GET.json)
 
@@ -1614,7 +1614,7 @@ Retrieve a specific viewpoint.
 
 **Resource URL**
 
-    GET /bcf/{version}/projects/{guid}/topics/{guid}/viewpoints/{guid}/snapshot
+    GET /bcf/{version}/projects/{project_id}/topics/{topic_id}/viewpoints/{viewpoint_guid}/snapshot
 
 Retrieve a viewpoints snapshot (png or jpg) as image file. A viewpoint contains a snapshot if viewpoint.snapshot != null.
 
@@ -1626,7 +1626,7 @@ Retrieve a viewpoints snapshot (png or jpg) as image file. A viewpoint contains 
 
 **Resource URL**
 
-    GET /bcf/{version}/projects/{guid}/topics/{guid}/viewpoints/{guid}/bitmaps/{guid}
+    GET /bcf/{version}/projects/{project_id}/topics/{topic_guid}/viewpoints/{viewpoint_guid}/bitmaps/{bitmap_guid}
 
 Retrieve a specific viewpoints bitmap image file (png or jpg).
 
@@ -1637,7 +1637,7 @@ Retrieve a specific viewpoints bitmap image file (png or jpg).
 ### 3.5.6 GET selected Components Service
 **Resource URL**
 
-    GET /bcf/{version}/projects/{project_id}/topics/{guid}/viewpoints/{guid}/selection
+    GET /bcf/{version}/projects/{project_id}/topics/{topic_guid}/viewpoints/{viewpoint_guid}/selection
 
 [selection_GET.json](Schemas_draft-03/Collaboration/Viewpoint/selection_GET.json)
 
@@ -1667,7 +1667,7 @@ Retrieve a **collection** of all selected components in a viewpoint.
 
 **Resource URL**
 
-    GET /bcf/{version}/projects/{project_id}/topics/{guid}/viewpoints/{guid}/coloring
+    GET /bcf/{version}/projects/{project_id}/topics/{topic_guid}/viewpoints/{viewpoint_guid}/coloring
 
 [coloring_GET.json](Schemas_draft-03/Collaboration/Viewpoint/coloring_GET.json)
 
@@ -1702,7 +1702,7 @@ Retrieve a **collection** of all colored components in a viewpoint.
 
 **Resource URL**
 
-    GET /bcf/{version}/projects/{project_id}/topics/{guid}/viewpoints/{guid}/visibility
+    GET /bcf/{version}/projects/{project_id}/topics/{topic_guid}/viewpoints/{viewpoint_guid}/visibility
 
 [visibility_GET.json](Schemas_draft-03/Collaboration/Viewpoint/visibility_GET.json)
 
@@ -1740,7 +1740,7 @@ Retrieve visibility of components in a viewpoint.
 
 **Resource URL**
 
-    DELETE /bcf/{version}/projects/{project_id}/topics/{guid}/viewpoints/{guid}
+    DELETE /bcf/{version}/projects/{project_id}/topics/{topic_guid}/viewpoints/{viewpoint_guid}
 
 Deletes a single viewpoint. This operation is only possible when the server returns the `delete` flag in the Viewpoint authorization, see section [3.5.10](#3510-determining-allowed-viewpoint-modifications)
 
@@ -1768,7 +1768,7 @@ overrides for each Viewpoint.
 
 **Resource URL**
 
-    GET /bcf/{version}/projects/{project_id}/topics/{guid}/related_topics
+    GET /bcf/{version}/projects/{project_id}/topics/{topic_guid}/related_topics
 
 [related_topic_GET.json](Schemas_draft-03/Collaboration/RelatedTopic/related_topic_GET.json)
 
@@ -1792,7 +1792,7 @@ Retrieve a **collection** of all related topics to a topic.
 
 **Resource URL**
 
-    PUT /bcf/{version}/projects/{project_id}/topics/{guid}/related_topics
+    PUT /bcf/{version}/projects/{project_id}/topics/{topic_guid}/related_topics
 
 [related_topic_PUT.json](Schemas_draft-03/Collaboration/RelatedTopic/related_topic_PUT.json)
 
@@ -1835,7 +1835,7 @@ A document_reference with **document_guid** set, is referencing an internal **do
 
 **Resource URL**
 
-    GET /bcf/{version}/projects/{project_id}/topics/{guid}/document_references
+    GET /bcf/{version}/projects/{project_id}/topics/{topic_guid}/document_references
 
 [document_reference_GET.json](Schemas_draft-03/Collaboration/DocumentReference/document_reference_GET.json)
 
@@ -1863,7 +1863,7 @@ Retrieve a **collection** of all document references to a topic.
 
 **Resource URL**
 
-    POST /bcf/{version}/projects/{project_id}/topics/{guid}/document_references
+    POST /bcf/{version}/projects/{project_id}/topics/{topic_guid}/document_references
 
 [document_reference_POST.json](Schemas_draft-03/Collaboration/DocumentReference/document_reference_POST.json)
 
@@ -1930,7 +1930,7 @@ JSON encoded body using the "application/json" content type.
 
 **Resource URL**
 
-    PUT /bcf/{version}/projects/{project_id}/topics/{guid}/document_references/{guid}
+    PUT /bcf/{version}/projects/{project_id}/topics/{topic_guid}/document_references/{document_guid}
 
 [document_reference_PUT.json](Schemas_draft-03/Collaboration/DocumentReference/document_reference_PUT.json)
 
@@ -2011,7 +2011,7 @@ Optional: The desired document guid may be passed as a query parameter.
 
 **Resource URL**
 
-    GET /bcf/{version}/projects/{project_id}/documents/{guid}
+    GET /bcf/{version}/projects/{project_id}/documents/{document_guid}
 
 Retrieves a document as binary file.
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@
 [BCF-API on SwaggerHub](https://app.swaggerhub.com/apis/buildingSMART/BCF/3.0)  
 > The Swagger / OpenAPI specification is offered as a reference for implementers. The BCF group may update it and fix issues as necessary at any time.
 
+# Contributing
+
+The Open CDE workgroup develops the BCF standard. The group meets every second Monday at 11am CET. To join the fortnightly meeting please email [opencde@buildingsmart.org](mailto:opencde@buildingsmart.org). 
+
 **Table of Contents**
 
 <!-- toc -->


### PR DESCRIPTION
Hi there,
I've located some inconsistencies on the paths.

project id as : {project_id}, but also as {guid}

It's not good practice to have the same parameter in the URL.

its better to define what guid is it relative to.

Regards,
Leo