### PR TITLE
Fix typo, and merge `release_3_0` into `master`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1751,7 +1751,7 @@ Deletes a single viewpoint. This operation is only possible when the server retu
 
 Note: If there is a comment associated to the viewpoint, the server might reject this request:
 - The server should return the http response status code 409
-- The client needs to disaccosiate this comment, before trying again.
+- The client needs to delete or unlink this comment, before trying again.
 
 **Example Request**
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The Open CDE workgroup develops the BCF standard. The group meets every second M
   * [1.2 Authorization](#12-authorization)
     + [1.2.1 Per-Entity Authorization](#121-per-entity-authorization)
     + [1.2.2 Determining Authorized Entity Actions](#122-determining-authorized-entity-actions)
+  * [1.3 Units of Numeric Values](#13-units-of-numeric-values)
 - [2. Topologies](#2-topologies)
   * [2.1 Topology 1 - BCF-Server only](#21-topology-1---bcf-server-only)
   * [2.2 Topology 2 - Colocated BCF-Server and Model Server](#22-topology-2---colocated-bcf-server-and-model-server)
@@ -190,6 +191,10 @@ Indicating that for this topic, the current user can:
 * update the Topic, or add comments or viewpoints
 * place the Topic into `closed` status
 * leave the Topic `open` or place the topic back into `open` status after closing it
+
+### 1.3 Units of Numeric Values
+
+Numeric values in this specification are all in fixed units - meters for length and degrees for angle.
 
 ----------
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@
 [BCF-API on SwaggerHub](https://app.swaggerhub.com/apis/buildingSMART/BCF/3.0)  
 > The Swagger / OpenAPI specification is offered as a reference for implementers. The BCF group may update it and fix issues as necessary at any time.
 
+# Contributing
+
+The Open CDE workgroup develops the BCF standard. The group meets every second Monday at 11am CET. To join the fortnightly meeting please email [opencde@buildingsmart.org](mailto:opencde@buildingsmart.org). 
+
 **Table of Contents**
 
 <!-- toc -->


### PR DESCRIPTION
I've based this on the latest `release_3_0` branch, and it also includes two commits that weren't part of `master` yet.